### PR TITLE
Sort version array as integers

### DIFF
--- a/components/visualstudio.ps1
+++ b/components/visualstudio.ps1
@@ -6,7 +6,7 @@ if ((Test-Path "hklm:\SOFTWARE\Microsoft\VisualStudio\SxS\VS7") -or (Test-Path "
 
     $vsRegistry = Get-Item "hklm:\SOFTWARE\Wow6432Node\Microsoft\VisualStudio\SxS\VS7" -ErrorAction SilentlyContinue
     if ($vsRegistry -eq $null) { $vsRegistry = Get-Item "hklm:\SOFTWARE\Microsoft\VisualStudio\SxS\VS7" }
-    $vsVersion  = $vsRegistry.property | Sort-Object -Descending | Select-Object -first 1
+    $vsVersion  = $vsRegistry.property | Sort-Object {[int]$_} -Descending | Select-Object -first 1
     $vsinstall  = ForEach-Object -process {$vsRegistry.GetValue($vsVersion)}
     Remove-Variable vsRegistry
 


### PR DESCRIPTION
Current string array sorting logic causes VS versions less than 10 to be selected first, e.g. 

8.0
14.0
12.0
11.0
10.0
