### PR TITLE
fix(install): correct security error on install

### DIFF
--- a/setup/install.ps1
+++ b/setup/install.ps1
@@ -14,8 +14,9 @@ function Download-File {
     [string]$file
   )
   Write-Host "Downloading $url to $file"
-  $downloader = new-object System.Net.WebClient
-  $downloader.DownloadFile($url, $file)
+  [Net.ServicePointManager]::SecurityProtocol = [Net.SecurityProtocolType]::Tls12
+  Invoke-WebRequest -Uri $url -OutFile $file
+
 }
 
 function Unzip-File {


### PR DESCRIPTION
Change archive download from github.com to use TLS 1.2
PowerShell defaults to 1.0, which GitHub no longer supports.

Fixes #22